### PR TITLE
Added as_i64 to IValue.

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -469,6 +469,11 @@ impl IValue {
         }
     }
 
+    /// Return i64 value only if the internal representation is i64, otherwise None.
+    pub fn as_i64(&self) -> Option<i64> {
+        self.as_number()?.as_i64()
+    }
+
     /// Converts this value to an i64 if it is a number that can be represented exactly.
     pub fn to_i64(&self) -> Option<i64> {
         self.as_number()?.to_i64()


### PR DESCRIPTION
Currently it is not possible to distinguish the internal representation of a number. Using `to_i64` will give you the value even if its f64. The new API will return i64 if the internal representation allows it and otherwise None.

If there is another API that I can use instead, please let me know and I will close this PR.