### PR TITLE
Correctly calculate offset to data following Header

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -279,7 +279,7 @@ impl Header {
                         .reverse(),
                     (NumberType::U64, _) => Ordering::Greater,
                     (_, NumberType::U64) => Ordering::Less,
-                    _ => (self.to_i64().cmp(&other.to_i64())),
+                    _ => self.to_i64().cmp(&other.to_i64()),
                 }
             }
         }
@@ -445,7 +445,7 @@ impl INumber {
     }
 
     fn new_i64(value: i64) -> Self {
-        if value >= SHORT_LOWER && value < SHORT_UPPER {
+        if (SHORT_LOWER..SHORT_UPPER).contains(&value) {
             Self::new_short(value as i32)
         } else {
             let mut res = Self::new_ptr(NumberType::I64);

--- a/src/number.rs
+++ b/src/number.rs
@@ -348,9 +348,26 @@ impl INumber {
         match type_ {
             NumberType::Static => unreachable!(),
             NumberType::I24 => {}
-            NumberType::I64 => res = res.extend(Layout::new::<i64>())?.0.pad_to_align(),
-            NumberType::U64 => res = res.extend(Layout::new::<u64>())?.0.pad_to_align(),
-            NumberType::F64 => res = res.extend(Layout::new::<f64>())?.0.pad_to_align(),
+            // On 32-bit Linux, 64-bit values have 4 byte alignment be we assume they have 8
+            // like on all other platforms. Therefore, ensure they are aligned to 8 bytes minimum.
+            NumberType::I64 => {
+                res = res
+                    .extend(Layout::new::<i64>().align_to(8)?)?
+                    .0
+                    .pad_to_align()
+            }
+            NumberType::U64 => {
+                res = res
+                    .extend(Layout::new::<u64>().align_to(8)?)?
+                    .0
+                    .pad_to_align()
+            }
+            NumberType::F64 => {
+                res = res
+                    .extend(Layout::new::<f64>().align_to(8)?)?
+                    .0
+                    .pad_to_align()
+            }
         }
         Ok(res)
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -61,7 +61,7 @@ pub struct IValue {
 
 /// Enum returned by [`IValue::destructure`] to allow matching on the type of
 /// an owned [`IValue`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Destructured {
     /// Null.
     Null,
@@ -95,7 +95,7 @@ impl Destructured {
 
 /// Enum returned by [`IValue::destructure_ref`] to allow matching on the type of
 /// a reference to an [`IValue`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DestructuredRef<'a> {
     /// Null.
     Null,


### PR DESCRIPTION
When an `INumber` value is created, for values other `NumberType::Static` or `NumberType::I24`, a `Header` is allocated with trailing space for the 64-bit data value. However, the calculation used to create the pointer to the data when accessing it via the `as_*_unchecked*` family of functions does not work properly because it first casts the `Header` pointer to a 64-bit value pointer _and then_ does the offset which is incorrect on platforms where the `Header` does not occupy 64-bits such as i686-unknown-linux-gnu.

As a result, the data pointer is incorrectly offset and partially points out of bounds for the allocation. This seems to work ok with some memory allocators (possibly because they round the allocation size up to the next power of 2 and so the adjacent memory is unused) but on others causes heap corruption leading to SIGSEV.

miri detects this situation and offers the following diagnostic:

```shell
$ cargo +nightly miri test --target=i686-unknown-linux-gnu -- can_store_various_numbers
...
running 1 test
test number::tests::can_store_various_numbers ... error: Undefined Behavior: dereferencing pointer failed: alloc135951 has size 12, so pointer to 8 bytes starting at offset 8 is out-of-bounds
   --> src/number.rs:79:9
    |
79  |         &mut *(self as *mut _ as *mut i64).add(1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereferencing pointer failed: alloc135951 has size 12, so pointer to 8 bytes starting at offset 8 is out-of-bounds
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `number::Header::as_i64_unchecked_mut` at src/number.rs:79:9
note: inside `number::INumber::new_i64` at src/number.rs:437:18
note: inside `<number::INumber as std::convert::From<i32>>::from` at src/number.rs:598:9
note: inside closure at src/number.rs:711:26
note: inside `number::tests::can_store_various_numbers` at src/number.rs:704:5
```

This corrects the logic used to generate the allocation so that `Header` has a consistent size and alignment.