### PR TITLE
Correct `is_object` typo.

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1100,4 +1100,12 @@ mod tests {
             assert!(matches!(x.clone().destructure_mut(), DestructuredMut::Object(u) if *u == o));
         }
     }
+
+    #[mockalloc::test]
+    fn test_into_object_for_object() {
+        let o: IObject = (0..10).map(|i| (i.to_string(), i)).collect();
+        let x = IValue::from(o.clone());
+
+        assert_eq!(x.into_object(), Ok(o));
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -690,7 +690,7 @@ impl IValue {
     ///
     /// Returns `Err(self)` if it's not an object.
     pub fn into_object(self) -> Result<IObject, IValue> {
-        if self.is_number() {
+        if self.is_object() {
             Ok(IObject(self))
         } else {
             Err(self)


### PR DESCRIPTION
It looks like there was a typo that made it so a IValue would be checked for its numerical-ness before being transformed into an object. This switches it to check for its object-ness. Addresses #21 