### PR TITLE
Added optional hash table `indexmap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ description = "A more memory efficient replacement for serde_json::Value"
 tracing = ["mockalloc/tracing"]
 
 [dependencies]
-dashmap = { version = "5.4", features = ["raw-api"] }
+dashmap = { version = "5.5", features = ["raw-api"] }
 lazy_static = "1.4.0"
-serde = "1.0.117"
-serde_json = "1.0.59"
-ctor = { version = "0.1.16", optional = true }
+serde = "1.0.173"
+serde_json = "1.0.103"
+ctor = { version = "0.2.4", optional = true }
 indexmap = { version = "2.0.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ lazy_static = "1.4.0"
 serde = "1.0.117"
 serde_json = "1.0.59"
 ctor = { version = "0.1.16", optional = true }
+indexmap = { version = "2.0.0", optional = true }
 
 [dev-dependencies]
 mockalloc = "0.1.2"

--- a/src/object.rs
+++ b/src/object.rs
@@ -3,16 +3,15 @@
 use std::alloc::{alloc, dealloc, Layout, LayoutError};
 use std::cmp::{self, Ordering};
 use std::collections::hash_map::DefaultHasher;
-#[cfg(feature = "indexmap")]
-use indexmap::IndexMap as DataMap;
-#[cfg(not(feature = "indexmap"))]
-use std::collections::BTreeMap as DataMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
 use std::mem;
 use std::ops::{Index, IndexMut};
+
+#[cfg(feature = "indexmap")]
+use indexmap::IndexMap;
 
 use crate::thin::{ThinMut, ThinMutExt, ThinRef, ThinRefExt};
 
@@ -1067,8 +1066,17 @@ impl<K: Into<IString>, V: Into<IValue>> From<HashMap<K, V>> for IObject {
     }
 }
 
-impl<K: Into<IString>, V: Into<IValue>> From<DataMap<K, V>> for IObject {
-    fn from(other: DataMap<K, V>) -> Self {
+impl<K: Into<IString>, V: Into<IValue>> From<BTreeMap<K, V>> for IObject {
+    fn from(other: BTreeMap<K, V>) -> Self {
+        let mut res = Self::with_capacity(other.len());
+        res.extend(other.into_iter().map(|(k, v)| (k.into(), v.into())));
+        res
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<K: Into<IString>, V: Into<IValue>> From<IndexMap<K, V>> for IObject {
+    fn from(other: IndexMap<K, V>) -> Self {
         let mut res = Self::with_capacity(other.len());
         res.extend(other.into_iter().map(|(k, v)| (k.into(), v.into())));
         res

--- a/src/object.rs
+++ b/src/object.rs
@@ -3,7 +3,11 @@
 use std::alloc::{alloc, dealloc, Layout, LayoutError};
 use std::cmp::{self, Ordering};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{BTreeMap, HashMap};
+#[cfg(feature = "indexmap")]
+use indexmap::IndexMap as DataMap;
+#[cfg(not(feature = "indexmap"))]
+use std::collections::BTreeMap as DataMap;
+use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
@@ -1063,8 +1067,8 @@ impl<K: Into<IString>, V: Into<IValue>> From<HashMap<K, V>> for IObject {
     }
 }
 
-impl<K: Into<IString>, V: Into<IValue>> From<BTreeMap<K, V>> for IObject {
-    fn from(other: BTreeMap<K, V>) -> Self {
+impl<K: Into<IString>, V: Into<IValue>> From<DataMap<K, V>> for IObject {
+    fn from(other: DataMap<K, V>) -> Self {
         let mut res = Self::with_capacity(other.len());
         res.extend(other.into_iter().map(|(k, v)| (k.into(), v.into())));
         res

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,9 +1,5 @@
 use std::cmp::Ordering;
-#[cfg(feature = "indexmap")]
-use indexmap::IndexMap as DataMap;
-#[cfg(not(feature = "indexmap"))]
-use std::collections::BTreeMap as DataMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
@@ -11,6 +7,9 @@ use std::hint::unreachable_unchecked;
 use std::mem;
 use std::ops::{Deref, Index, IndexMut};
 use std::ptr::NonNull;
+
+#[cfg(feature = "indexmap")]
+use indexmap::IndexMap;
 
 use super::array::IArray;
 use super::number::INumber;
@@ -947,6 +946,7 @@ impl From<bool> for IValue {
     }
 }
 
+#[cfg(not(feature = "indexmap"))]
 typed_conversions! {
     INumber: i8, u8, i16, u16, i32, u32, i64, u64, isize, usize;
     IString: String, &String, &mut String, &str, &mut str;
@@ -955,7 +955,20 @@ typed_conversions! {
         &[T] where (T: Into<IValue> + Clone);
     IObject:
         HashMap<K, V> where (K: Into<IString>, V: Into<IValue>),
-        DataMap<K, V> where (K: Into<IString>, V: Into<IValue>);
+        BTreeMap<K, V> where (K: Into<IString>, V: Into<IValue>);
+}
+
+#[cfg(feature = "indexmap")]
+typed_conversions! {
+    INumber: i8, u8, i16, u16, i32, u32, i64, u64, isize, usize;
+    IString: String, &String, &mut String, &str, &mut str;
+    IArray:
+        Vec<T> where (T: Into<IValue>),
+        &[T] where (T: Into<IValue> + Clone);
+    IObject:
+        HashMap<K, V> where (K: Into<IString>, V: Into<IValue>),
+        BTreeMap<K, V> where (K: Into<IString>, V: Into<IValue>),
+        IndexMap<K, V> where (K: Into<IString>, V: Into<IValue>);
 }
 
 impl From<f32> for IValue {

--- a/src/value.rs
+++ b/src/value.rs
@@ -946,7 +946,6 @@ impl From<bool> for IValue {
     }
 }
 
-#[cfg(not(feature = "indexmap"))]
 typed_conversions! {
     INumber: i8, u8, i16, u16, i32, u32, i64, u64, isize, usize;
     IString: String, &String, &mut String, &str, &mut str;
@@ -960,14 +959,7 @@ typed_conversions! {
 
 #[cfg(feature = "indexmap")]
 typed_conversions! {
-    INumber: i8, u8, i16, u16, i32, u32, i64, u64, isize, usize;
-    IString: String, &String, &mut String, &str, &mut str;
-    IArray:
-        Vec<T> where (T: Into<IValue>),
-        &[T] where (T: Into<IValue> + Clone);
     IObject:
-        HashMap<K, V> where (K: Into<IString>, V: Into<IValue>),
-        BTreeMap<K, V> where (K: Into<IString>, V: Into<IValue>),
         IndexMap<K, V> where (K: Into<IString>, V: Into<IValue>);
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,5 +1,9 @@
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap};
+#[cfg(feature = "indexmap")]
+use indexmap::IndexMap as DataMap;
+#[cfg(not(feature = "indexmap"))]
+use std::collections::BTreeMap as DataMap;
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
@@ -951,7 +955,7 @@ typed_conversions! {
         &[T] where (T: Into<IValue> + Clone);
     IObject:
         HashMap<K, V> where (K: Into<IString>, V: Into<IValue>),
-        BTreeMap<K, V> where (K: Into<IString>, V: Into<IValue>);
+        DataMap<K, V> where (K: Into<IString>, V: Into<IValue>);
 }
 
 impl From<f32> for IValue {


### PR DESCRIPTION
First of all, thank you for this dependency and all your hard work on it.

Personally I use `IndexMap` instead of `BTreeMap` for my projects, so I think it would be nice to give people the option to choose `IndexMap` as the preferred hash table.

https://github.com/bluss/indexmap/issues/269
```
test a_new_btreemap       ... bench:           1 ns/iter (+/- 0)
test a_new_indexmap       ... bench:           3 ns/iter (+/- 0)

test b_insert_btreemap    ... bench:  60,621,040 ns/iter (+/- 15,248,541)
test b_insert_indexmap    ... bench:  42,826,040 ns/iter (+/- 1,214,166)

test c_clone_btreemap     ... bench:  41,720,370 ns/iter (+/- 1,932,831)
test c_clone_indexmap     ... bench:  39,500,870 ns/iter (+/- 1,026,400)

test d_for_each_btreemap  ... bench:   8,487,320 ns/iter (+/- 112,188)
test d_for_each_indexmap  ... bench:   7,427,390 ns/iter (+/- 177,412)

test e_find_btreemap      ... bench:          16 ns/iter (+/- 1)
test e_find_indexmap      ... bench:          13 ns/iter (+/- 0)

test f_rfind_btreemap     ... bench:          23 ns/iter (+/- 1)
test f_rfind_indexmap     ... bench:          14 ns/iter (+/- 0)
```

**//Edit**
I also updated all dependencies directly