### PR TITLE
Add a Display impl for IValue

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1,12 +1,12 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
-use std::fmt::{self, Debug, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::Hash;
 use std::hint::unreachable_unchecked;
-use std::mem;
 use std::ops::{Deref, Index, IndexMut};
 use std::ptr::NonNull;
+use std::{io, mem};
 
 #[cfg(feature = "indexmap")]
 use indexmap::IndexMap;
@@ -901,6 +901,41 @@ impl<I: ValueIndex> IndexMut<I> for IValue {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut IValue {
         index.index_or_insert(self)
+    }
+}
+
+impl Display for IValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        struct WriterFormatter<'a, 'b: 'a> {
+            inner: &'a mut fmt::Formatter<'b>,
+        }
+        impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                // Safety: the serializer below only emits valid utf8 when using
+                // the default formatter.
+                let s = unsafe { str::from_utf8_unchecked(buf) };
+
+                // Error value does not matter because Display impl just maps it
+                // back to fmt::Error.
+                let io_error = |_| io::Error::new(io::ErrorKind::Other, "fmt error");
+                self.inner.write_str(s).map_err(io_error)?;
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let alternate = f.alternate();
+        let mut wr = WriterFormatter { inner: f };
+        if alternate {
+            // {:#}
+            serde_json::to_writer_pretty(&mut wr, self).map_err(|_| fmt::Error)
+        } else {
+            // {}
+            serde_json::to_writer(&mut wr, self).map_err(|_| fmt::Error)
+        }
     }
 }
 


### PR DESCRIPTION
The serde_json::Value implements Display, so for IValue to be a drop-in replacement, it would need to also implement Display

Considerations
--------------

Since ijson itself doesn't implement Ser/Deser but defers the responsibility to end users, it doesn't make sense to implement Display in this crate, does it?

Up to the maintainers to decide.

I went ahead anyway, and used the serde_json serializer, since the crate already depends on serde_json. The code is more-or-less a copy/paste from the serde_json::Value Display impl.

See: https://docs.rs/serde_json/latest/src/serde_json/value/mod.rs.html#197-257

Alternatives
------------

I considered that a `.display(serializer)` method on IValue, similar to Path::display could make sense. But then, is it really worth it, if you have to specify the way it's serialized?

----

btw congratulation on the nice crate. I really like the idea behind it. Thank you if you take the time to bother with my PR too.

Cheers.