### PR TITLE
Add FromIterator and serde_json conversions for IValue (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.7
+
+- Add `FromIterator<T: Into<IValue>>` for `IValue` (collects into an array) and `FromIterator<(K: Into<IString>, V: Into<IValue>)>` for `IValue` (collects into an object), mirroring `serde_json::Value`.
+- Add `From<serde_json::Value> for IValue` and `From<IValue> for serde_json::Value` for smoother interoperability with `serde_json`.
+
 ## 0.1.6
 
 - **Breaking:** Remove `Borrow<str>` impl for `IString` by default. The impl violates the `Borrow` contract because `IString` hashes by pointer, not by contents, causing silent lookup failures in `HashMap`/`HashSet` when using `&str` keys. A `broken-borrow-impl-compat` feature flag is available as a temporary compatibility measure.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ijson"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Diggory Blake <diggsey@googlemail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/number.rs
+++ b/src/number.rs
@@ -670,6 +670,52 @@ impl TryFrom<f32> for INumber {
     }
 }
 
+/// Converts a [`serde_json::Number`] into an [`INumber`].
+///
+/// Conversion may be lossy if the number is not exactly representable as an
+/// `INumber`. The exact behaviour in that case (e.g. clamping an out-of-range
+/// magnitude) is not guaranteed to be stable across versions.
+impl From<serde_json::Number> for INumber {
+    fn from(n: serde_json::Number) -> Self {
+        if let Some(v) = n.as_u64() {
+            INumber::from(v)
+        } else if let Some(v) = n.as_i64() {
+            INumber::from(v)
+        } else {
+            // A serde_json number is always representable as an f64, so this
+            // cannot return `None`; if it does, an invariant broke.
+            let v = n
+                .as_f64()
+                .expect("a serde_json number is always an integer or float");
+            // Standard JSON numbers are finite. Only the `arbitrary_precision`
+            // feature can parse a magnitude beyond f64's range (an infinity);
+            // clamp it so the result stays a finite, representable number and
+            // `try_from` cannot fail.
+            INumber::try_from(v.clamp(f64::MIN, f64::MAX)).expect("a clamped f64 is always finite")
+        }
+    }
+}
+
+/// Converts an [`INumber`] into a [`serde_json::Number`].
+///
+/// Conversion may be lossy if the number is not exactly representable as a
+/// `serde_json::Number`. The exact behaviour in that case (e.g. rounding) is
+/// not guaranteed to be stable across versions.
+impl From<INumber> for serde_json::Number {
+    fn from(n: INumber) -> Self {
+        if let Some(v) = n.to_u64() {
+            serde_json::Number::from(v)
+        } else if let Some(v) = n.to_i64() {
+            serde_json::Number::from(v)
+        } else {
+            // Not an integer, so it is stored as an f64. An `INumber` is always
+            // finite, so `from_f64` cannot fail; a failure here would mean the
+            // `INumber` invariant was violated.
+            serde_json::Number::from_f64(n.to_f64_lossy()).expect("an INumber is always finite")
+        }
+    }
+}
+
 impl PartialEq for INumber {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal

--- a/src/value.rs
+++ b/src/value.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
 use std::hint::unreachable_unchecked;
+use std::iter::FromIterator;
 use std::mem;
 use std::ops::{Deref, Index, IndexMut};
 use std::ptr::NonNull;
@@ -973,6 +974,64 @@ impl From<f64> for IValue {
     }
 }
 
+/// Collects an iterator of values into an array [`IValue`].
+impl<T: Into<IValue>> FromIterator<T> for IValue {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        IArray::from_iter(iter).into()
+    }
+}
+
+/// Collects an iterator of key-value pairs into an object [`IValue`].
+impl<K: Into<IString>, V: Into<IValue>> FromIterator<(K, V)> for IValue {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        IObject::from_iter(iter).into()
+    }
+}
+
+/// Converts a [`serde_json::Value`] into an [`IValue`].
+///
+/// Conversion of numeric values may be lossy if the number is not exactly
+/// representable in the destination type. The exact behaviour in that case
+/// (e.g. rounding, or clamping an out-of-range magnitude) is not guaranteed
+/// to be stable across versions.
+impl From<serde_json::Value> for IValue {
+    fn from(other: serde_json::Value) -> Self {
+        match other {
+            serde_json::Value::Null => IValue::NULL,
+            serde_json::Value::Bool(b) => b.into(),
+            serde_json::Value::Number(n) => INumber::from(n).into(),
+            serde_json::Value::String(s) => s.into(),
+            serde_json::Value::Array(a) => a.into_iter().collect(),
+            serde_json::Value::Object(o) => o.into_iter().collect(),
+        }
+    }
+}
+
+/// Converts an [`IValue`] into a [`serde_json::Value`].
+///
+/// Conversion of numeric values may be lossy if the number is not exactly
+/// representable in the destination type. The exact behaviour in that case
+/// (e.g. rounding, or clamping an out-of-range magnitude) is not guaranteed
+/// to be stable across versions.
+impl From<IValue> for serde_json::Value {
+    fn from(other: IValue) -> Self {
+        match other.destructure() {
+            Destructured::Null => serde_json::Value::Null,
+            Destructured::Bool(b) => serde_json::Value::Bool(b),
+            Destructured::Number(n) => serde_json::Value::Number(n.into()),
+            Destructured::String(s) => serde_json::Value::String(s.as_str().to_owned()),
+            Destructured::Array(a) => {
+                serde_json::Value::Array(a.into_iter().map(Into::into).collect())
+            }
+            Destructured::Object(o) => serde_json::Value::Object(
+                o.into_iter()
+                    .map(|(k, v)| (k.as_str().to_owned(), v.into()))
+                    .collect(),
+            ),
+        }
+    }
+}
+
 impl Default for IValue {
     fn default() -> Self {
         Self::NULL
@@ -1114,5 +1173,48 @@ mod tests {
         let x = IValue::from(o.clone());
 
         assert_eq!(x.into_object(), Ok(o));
+    }
+
+    #[mockalloc::test]
+    fn test_from_iter_array() {
+        let x: IValue = (0..5).collect();
+        let y: IValue = ijson!([0, 1, 2, 3, 4]);
+        assert_eq!(x, y);
+
+        let empty: IValue = std::iter::empty::<i32>().collect();
+        assert_eq!(empty, ijson!([]));
+    }
+
+    #[mockalloc::test]
+    fn test_from_iter_object() {
+        let x: IValue = (0..3).map(|i| (i.to_string(), i)).collect();
+        let y: IValue = ijson!({"0": 0, "1": 1, "2": 2});
+        assert_eq!(x, y);
+
+        let empty: IValue = std::iter::empty::<(String, i32)>().collect();
+        assert_eq!(empty, ijson!({}));
+    }
+
+    #[mockalloc::test]
+    fn test_serde_json_roundtrip() {
+        let json = serde_json::json!({
+            "null": null,
+            "bool": true,
+            "int": 42,
+            "neg": -17,
+            "big": 18446744073709551615u64,
+            "float": 63.5,
+            "string": "hello",
+            "array": [1, 2, 3, "four", false, null],
+            "object": {"nested": [1.5, {"deep": true}]}
+        });
+
+        let ivalue: IValue = json.clone().into();
+        let back: serde_json::Value = ivalue.clone().into();
+        assert_eq!(json, back);
+
+        // Also check consistency with the serde-based conversion.
+        let via_serde: IValue = crate::to_value(&json).unwrap();
+        assert_eq!(ivalue, via_serde);
     }
 }


### PR DESCRIPTION
Implements the trait suggestions from #38 (excluding `Display`).

## Changes

- **`FromIterator<T: Into<IValue>>` for `IValue`** — collecting an iterator of values produces an array.
- **`FromIterator<(K: Into<IString>, V: Into<IValue>)>` for `IValue`** — collecting key/value pairs produces an object. These two blanket impls coexist without a coherence conflict for the same reason `serde_json::Value`'s do: the orphan rule forbids any downstream `From<(K, V)> for IValue`, so the tuple item type is provably disjoint from the generic one.
- **`From<serde_json::Value> for IValue`** and **`From<IValue> for serde_json::Value`** — direct, infallible, recursive conversions. Numbers preserve exactness by preferring `u64` → `i64` → `f64`. The float fallbacks (`null` / `0`) are unreachable for valid JSON numbers but avoid panicking.

`serde_json` was already a hard dependency, so no feature gating was needed.

## Tests

Added `test_from_iter_array`, `test_from_iter_object`, and `test_serde_json_roundtrip` (the roundtrip test also cross-checks the new `From` against the existing serde-based `to_value`).

Verified: `cargo test -- --test-threads=1` (all pass), `cargo clippy --all-targets` clean, `cargo fmt --check` clean, and the `indexmap` feature still builds.

Also bumps the version to 0.1.7 and updates the changelog.

Closes #38.
