### PR TITLE
Add IObject <-> serde_json::Map conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `FromIterator<T: Into<IValue>>` for `IValue` (collects into an array) and `FromIterator<(K: Into<IString>, V: Into<IValue>)>` for `IValue` (collects into an object), mirroring `serde_json::Value`.
 - Add `From<serde_json::Value> for IValue` and `From<IValue> for serde_json::Value` for smoother interoperability with `serde_json`.
+- Add `From<serde_json::Map<String, serde_json::Value>> for IObject` and the reverse, matching the existing `HashMap`/`BTreeMap`/`IndexMap` conversions.
 
 ## 0.1.6
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -1085,6 +1085,33 @@ impl<K: Into<IString>, V: Into<IValue>> From<IndexMap<K, V>> for IObject {
     }
 }
 
+/// Converts a [`serde_json::Map`] into an [`IObject`].
+///
+/// Conversion of numeric values may be lossy if a number is not exactly
+/// representable in the destination type. The exact behaviour in that case is
+/// not guaranteed to be stable across versions.
+impl From<serde_json::Map<String, serde_json::Value>> for IObject {
+    fn from(other: serde_json::Map<String, serde_json::Value>) -> Self {
+        let mut res = Self::with_capacity(other.len());
+        res.extend(other.into_iter().map(|(k, v)| (k, IValue::from(v))));
+        res
+    }
+}
+
+/// Converts an [`IObject`] into a [`serde_json::Map`].
+///
+/// Conversion of numeric values may be lossy if a number is not exactly
+/// representable in the destination type. The exact behaviour in that case is
+/// not guaranteed to be stable across versions.
+impl From<IObject> for serde_json::Map<String, serde_json::Value> {
+    fn from(other: IObject) -> Self {
+        other
+            .into_iter()
+            .map(|(k, v)| (k.as_str().to_owned(), serde_json::Value::from(v)))
+            .collect()
+    }
+}
+
 impl Default for IObject {
     fn default() -> Self {
         Self::new()
@@ -1117,6 +1144,23 @@ mod tests {
         assert_eq!(y["a"], IValue::NULL);
         assert_eq!(y["b"], IValue::TRUE);
         assert_eq!(y["c"], IValue::FALSE);
+    }
+
+    #[mockalloc::test]
+    fn can_convert_serde_json_map() {
+        let mut map = serde_json::Map::new();
+        map.insert("a".to_owned(), serde_json::Value::Null);
+        map.insert("b".to_owned(), serde_json::json!(42));
+        map.insert("c".to_owned(), serde_json::json!("hi"));
+
+        let obj = IObject::from(map.clone());
+        assert_eq!(obj.len(), 3);
+        assert_eq!(obj["a"], IValue::NULL);
+        assert_eq!(obj["b"], IValue::from(42));
+        assert_eq!(obj["c"], IValue::from("hi"));
+
+        let back: serde_json::Map<String, serde_json::Value> = obj.into();
+        assert_eq!(back, map);
     }
 
     #[mockalloc::test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -1002,7 +1002,7 @@ impl From<serde_json::Value> for IValue {
             serde_json::Value::Number(n) => INumber::from(n).into(),
             serde_json::Value::String(s) => s.into(),
             serde_json::Value::Array(a) => a.into_iter().collect(),
-            serde_json::Value::Object(o) => o.into_iter().collect(),
+            serde_json::Value::Object(o) => IObject::from(o).into(),
         }
     }
 }
@@ -1023,11 +1023,7 @@ impl From<IValue> for serde_json::Value {
             Destructured::Array(a) => {
                 serde_json::Value::Array(a.into_iter().map(Into::into).collect())
             }
-            Destructured::Object(o) => serde_json::Value::Object(
-                o.into_iter()
-                    .map(|(k, v)| (k.as_str().to_owned(), v.into()))
-                    .collect(),
-            ),
+            Destructured::Object(o) => serde_json::Value::Object(o.into()),
         }
     }
 }


### PR DESCRIPTION
Follow-up to #39. While surveying the crate for missing trait impls similar to the ones just merged, the clearest gap was that `IObject` can be built from `HashMap`, `BTreeMap`, and `IndexMap`, but not from serde_json's *own* object type — even though `INumber ⇄ serde_json::Number` now exists.

## Changes

- `From<serde_json::Map<String, serde_json::Value>> for IObject`
- `From<IObject> for serde_json::Map<String, serde_json::Value>`

Both carry the same lossy/unstable numeric-conversion doc note as the other serde_json bridges. The `IValue ⇄ serde_json::Value` object branches now delegate to these impls rather than collecting element-by-element.

Added `can_convert_serde_json_map` exercising a round-trip.

Verified: `cargo test -- --test-threads=1` (32 pass), `cargo clippy --all-targets --features indexmap` clean, `cargo fmt --check` clean.

## Other gaps found (not in this PR)

For the record, the survey also turned up (left out by request):

- `IValue` ⇄ primitive `PartialEq` (a full `== "str" / == 42 / == true` matrix that `serde_json::Value` has; `IValue` has none)
- `FromStr for IValue`
- `IString: PartialEq<&str>` (`istring == "literal"` doesn't compile today)
- `From<IArray> for Vec<serde_json::Value>` (reverse of the already-working `From<Vec<T>>`)

Happy to do any of these in a follow-up.
