### PR TITLE
Add crates.io keywords and categories (#33)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Diggsey/ijson"
 description = "A more memory efficient replacement for serde_json::Value"
+keywords = ["json", "serde", "string-interning", "memory-efficient", "value"]
+categories = ["data-structures", "encoding"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]


### PR DESCRIPTION
Closes #33.

Adds package metadata to improve discoverability on crates.io:

```toml
keywords = ["json", "serde", "string-interning", "memory-efficient", "value"]
categories = ["data-structures", "encoding"]
```

`json` is the specifically requested keyword (commonly searched/filtered); the rest capture the crate's core identity — serde interop, its string-interning and memory-efficiency selling points, and that it's a `Value` type. crates.io caps keywords at 5 (≤20 chars each), so this uses the full budget.

Both categories (`data-structures`, `encoding`) are valid crates.io slugs. Validated locally with `cargo package --list` (no keyword length/count errors); category slugs are checked server-side on publish.

Metadata-only — no API or behaviour change, so no changelog entry.
