### PR TITLE
Store short strings inline instead of interning them (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `FromIterator<T: Into<IValue>>` for `IValue` (collects into an array) and `FromIterator<(K: Into<IString>, V: Into<IValue>)>` for `IValue` (collects into an object), mirroring `serde_json::Value`.
 - Add `From<serde_json::Value> for IValue` and `From<IValue> for serde_json::Value` for smoother interoperability with `serde_json`.
 - Add `From<serde_json::Map<String, serde_json::Value>> for IObject` and the reverse, matching the existing `HashMap`/`BTreeMap`/`IndexMap` conversions.
+- Store very short strings (up to 7 bytes on 64-bit, 3 bytes on 32-bit) inline within the value instead of interning them, avoiding an allocation and a global-cache lookup for the common case of short keys and values. Note: `IString::as_str().as_ptr()` is no longer stable across equal short strings, since they are no longer deduplicated to a shared allocation (value equality via `==` is unaffected).
 
 ## 0.1.6
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -15,10 +15,38 @@ use lazy_static::lazy_static;
 use crate::alloc::{alloc_infallible, dealloc_infallible};
 use crate::thin::{ThinMut, ThinMutExt, ThinRef, ThinRefExt};
 
-use super::value::{IValue, TypeTag};
+use super::value::{IValue, TypeTag, INLINE_STRING_FLAG};
 
+/// The number of string bytes that fit inline in a pointer-sized [`IValue`].
+/// This is 7 on 64-bit platforms and 3 on 32-bit platforms (one byte is used
+/// for the tag, inline flag, and length).
+pub(crate) const INLINE_CAPACITY: usize = std::mem::size_of::<usize>() - 1;
+
+// The inline string control byte occupies the low byte of the value. It stores
+// the `StringOrNull` tag (bits 0-1), the inline flag (bit 2, matching
+// `INLINE_STRING_FLAG`), and the length (bits 3-5). The remaining bytes hold up
+// to `INLINE_CAPACITY` UTF-8 bytes. `INLINE_STRING_FLAG` is a `usize`, so the
+// byte-sized form is asserted equal below.
+const INLINE_LEN_SHIFT: u32 = 3;
+const INLINE_LEN_MASK: usize = 0b111;
+
+// Memory offsets (within the value) of the control byte and the first character
+// byte. The control byte must be the low byte of the integer value (so the tag
+// and inline flag land in the low bits), which is offset 0 on little-endian and
+// the top byte on big-endian. The characters follow in ascending memory order.
+#[cfg(target_endian = "little")]
+const INLINE_CONTROL_OFFSET: usize = 0;
+#[cfg(target_endian = "little")]
+const INLINE_CHAR_OFFSET: usize = 1;
+#[cfg(target_endian = "big")]
+const INLINE_CONTROL_OFFSET: usize = std::mem::size_of::<usize>() - 1;
+#[cfg(target_endian = "big")]
+const INLINE_CHAR_OFFSET: usize = 0;
+
+// A heap string header is 8-aligned so that bit 2 of a heap string pointer is
+// always clear, letting it double as the inline discriminator.
 #[repr(C)]
-#[repr(align(4))]
+#[repr(align(8))]
 struct Header {
     rc: AtomicUsize,
     // We use 48 bits for the length and 16 bits for the shard index.
@@ -133,6 +161,11 @@ impl WeakIString {
 /// Interning uses `DashSet`, an implementation of a concurrent hash-set, allowing
 /// many strings to be interned concurrently without becoming a bottleneck.
 ///
+/// Very short strings (up to 7 bytes on 64-bit platforms, 3 bytes on 32-bit) are
+/// stored inline within the value itself, so they require no allocation and are
+/// never entered into the global cache. Equality and hashing remain correct
+/// because a given string always uses exactly one representation.
+///
 /// Given the nature of `IString` it is better to intern a string once and reuse
 /// it, rather than continually convert from `&str` to `IString`.
 #[repr(transparent)]
@@ -141,14 +174,41 @@ pub struct IString(pub(crate) IValue);
 
 value_subtype_impls!(IString, into_string, as_string, as_string_mut);
 
-static EMPTY_HEADER: Header = Header {
-    len_lower: 0,
-    len_upper: 0,
-    shard_index: 0,
-    rc: AtomicUsize::new(0),
-};
-
 impl IString {
+    // Encodes a string of at most `INLINE_CAPACITY` bytes directly into the
+    // pointer-sized value, avoiding any allocation or interning.
+    fn new_inline(s: &str) -> Self {
+        debug_assert!(s.len() <= INLINE_CAPACITY);
+        // The byte-sized inline flag must match the shared `usize` constant.
+        debug_assert_eq!(INLINE_STRING_FLAG, 0b100);
+
+        let mut bytes = [0u8; std::mem::size_of::<usize>()];
+        bytes[INLINE_CONTROL_OFFSET] =
+            TypeTag::StringOrNull as u8 | 0b100 | ((s.len() as u8) << INLINE_LEN_SHIFT);
+        bytes[INLINE_CHAR_OFFSET..INLINE_CHAR_OFFSET + s.len()].copy_from_slice(s.as_bytes());
+
+        // Safety: the control byte sets the `StringOrNull` tag and inline flag,
+        // so the value is non-zero and correctly discriminated.
+        unsafe { IString(IValue::new_inline_string(usize::from_ne_bytes(bytes))) }
+    }
+
+    // The byte length of an inline string, read from the control byte.
+    fn inline_len(&self) -> usize {
+        (self.0.ptr_usize() >> INLINE_LEN_SHIFT) & INLINE_LEN_MASK
+    }
+
+    // The UTF-8 bytes of an inline string, borrowed from within `self`.
+    fn inline_bytes(&self) -> &[u8] {
+        let len = self.inline_len();
+        // Safety: `self` is an inline string (checked by callers). Its character
+        // bytes live within its own storage at `INLINE_CHAR_OFFSET`, and
+        // `len <= INLINE_CAPACITY` fits within the value.
+        unsafe {
+            let base = (&self.0 as *const IValue).cast::<u8>();
+            std::slice::from_raw_parts(base.add(INLINE_CHAR_OFFSET), len)
+        }
+    }
+
     fn layout(len: usize) -> Result<Layout, LayoutError> {
         Ok(Layout::new::<Header>()
             .extend(Layout::array::<u8>(len)?)?
@@ -181,11 +241,15 @@ impl IString {
         }
     }
 
-    /// Converts a `&str` to an `IString` by interning it in the global string cache.
+    /// Converts a `&str` to an `IString`.
+    ///
+    /// Very short strings (up to 7 bytes on 64-bit platforms, 3 bytes on 32-bit)
+    /// are stored inline in the value itself, without allocating or touching the
+    /// global cache. Longer strings are interned in the global string cache.
     #[must_use]
     pub fn intern(s: &str) -> Self {
-        if s.is_empty() {
-            return Self::new();
+        if s.len() <= INLINE_CAPACITY {
+            return Self::new_inline(s);
         }
         let cache = &*STRING_CACHE;
         let shard_index = cache.determine_map(s);
@@ -205,14 +269,20 @@ impl IString {
         }
     }
 
+    // Safety: must only be called on a heap (interned) string, not an inline one.
     fn header<'a>(&'a self) -> ThinRef<'a, Header> {
+        debug_assert!(!self.0.is_inline_string());
         unsafe { ThinRef::new(self.0.ptr().cast()) }
     }
 
     /// Returns the length (in bytes) of this string.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.header().len()
+        if self.0.is_inline_string() {
+            self.inline_len()
+        } else {
+            self.header().len()
+        }
     }
 
     /// Returns `true` if this is the empty string "".
@@ -224,68 +294,74 @@ impl IString {
     /// Obtains a `&str` from this `IString`. This is a cheap operation.
     #[must_use]
     pub fn as_str(&self) -> &str {
-        self.header().str()
+        // Safety: inline and heap string bytes are both valid UTF-8 by construction.
+        unsafe { std::str::from_utf8_unchecked(self.as_bytes()) }
     }
 
     /// Obtains a byte slice from this `IString`. This is a cheap operation.
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
-        self.header().bytes()
+        if self.0.is_inline_string() {
+            self.inline_bytes()
+        } else {
+            self.header().bytes()
+        }
     }
 
     /// Returns the empty string.
     #[must_use]
     pub fn new() -> Self {
-        unsafe { IString(IValue::new_ref(&EMPTY_HEADER, TypeTag::StringOrNull)) }
+        Self::new_inline("")
     }
 
     pub(crate) fn clone_impl(&self) -> IValue {
-        if self.is_empty() {
-            Self::new().0
-        } else {
+        // Inline strings are trivially copyable; only heap strings are refcounted.
+        if !self.0.is_inline_string() {
             self.header().rc.fetch_add(1, AtomicOrdering::Relaxed);
-            unsafe { self.0.raw_copy() }
         }
+        unsafe { self.0.raw_copy() }
     }
     pub(crate) fn drop_impl(&mut self) {
-        if !self.is_empty() {
-            let hd = self.header();
+        // Inline strings own no allocation, so there is nothing to free.
+        if self.0.is_inline_string() {
+            return;
+        }
+        let hd = self.header();
 
-            // If the reference count is greater than 1, we can safely decrement it without
-            // locking the string cache.
-            let mut rc = hd.rc.load(AtomicOrdering::Relaxed);
-            while rc > 1 {
-                match hd.rc.compare_exchange_weak(
-                    rc,
-                    rc - 1,
-                    AtomicOrdering::Relaxed,
-                    AtomicOrdering::Relaxed,
-                ) {
-                    Ok(_) => return,
-                    Err(new_rc) => rc = new_rc,
-                }
+        // If the reference count is greater than 1, we can safely decrement it without
+        // locking the string cache.
+        let mut rc = hd.rc.load(AtomicOrdering::Relaxed);
+        while rc > 1 {
+            match hd.rc.compare_exchange_weak(
+                rc,
+                rc - 1,
+                AtomicOrdering::Relaxed,
+                AtomicOrdering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(new_rc) => rc = new_rc,
             }
+        }
 
-            // Slow path: we observed a reference count of 1, so we need to lock the string cache
-            let cache = &*STRING_CACHE;
-            // Safety: the number of shards is fixed
-            let shard = unsafe { cache.shards().get_unchecked(hd.shard_index()) };
-            let mut guard = shard.write();
-            if hd.rc.fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
-                // Reference count reached zero, free the string
-                assert!(guard.remove(hd.str()).is_some());
+        // Slow path: we observed a reference count of 1, so we need to lock the string cache
+        let cache = &*STRING_CACHE;
+        // Safety: the number of shards is fixed
+        let shard = unsafe { cache.shards().get_unchecked(hd.shard_index()) };
+        let mut guard = shard.write();
+        if hd.rc.fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
+            // Reference count reached zero, free the string
+            assert!(guard.remove(hd.str()).is_some());
 
-                // Shrink the shard if it's mostly empty.
-                // The second condition is necessary because `HashMap` sometimes
-                // reports a capacity of zero even when it's still backed by an
-                // allocation.
-                if guard.len() * 3 < guard.capacity() || guard.is_empty() {
-                    guard.shrink_to_fit();
-                }
-                drop(guard);
-
-                Self::dealloc(unsafe { self.0.ptr().cast() });
+            // Shrink the shard if it's mostly empty.
+            // The second condition is necessary because `HashMap` sometimes
+            // reports a capacity of zero even when it's still backed by an
+            // allocation.
+            if guard.len() * 3 < guard.capacity() || guard.is_empty() {
+                guard.shrink_to_fit();
             }
+            drop(guard);
+
+            Self::dealloc(unsafe { self.0.ptr().cast() });
         }
     }
 }
@@ -425,25 +501,104 @@ impl Display for IString {
 mod tests {
     use super::*;
 
+    // A string long enough to always be heap-interned on any platform.
+    const LONG_A: &str = "interned_string_a";
+    const LONG_B: &str = "interned_string_b";
+
     #[mockalloc::test]
     fn can_intern() {
-        let x = IString::intern("foo");
-        let y = IString::intern("bar");
-        let z = IString::intern("foo");
+        // Long strings share a single interned allocation (pointer identity).
+        let x = IString::intern(LONG_A);
+        let y = IString::intern(LONG_B);
+        let z = IString::intern(LONG_A);
 
         assert_eq!(x.as_ptr(), z.as_ptr());
         assert_ne!(x.as_ptr(), y.as_ptr());
-        assert_eq!(x.as_str(), "foo");
-        assert_eq!(y.as_str(), "bar");
+        assert_eq!(x.as_str(), LONG_A);
+        assert_eq!(y.as_str(), LONG_B);
     }
 
     #[mockalloc::test]
     fn default_interns_string() {
-        let x = IString::intern("");
-        let y = IString::new();
-        let z = IString::intern("foo");
+        let x = IString::intern(LONG_A);
+        let y = IString::intern(LONG_A);
 
         assert_eq!(x.as_ptr(), y.as_ptr());
-        assert_ne!(x.as_ptr(), z.as_ptr());
+    }
+
+    #[mockalloc::test]
+    fn short_strings_are_inline() {
+        // Strings up to INLINE_CAPACITY bytes are stored inline: no allocation,
+        // and they still compare equal by value.
+        let mut cases: Vec<String> = vec![
+            String::new(),
+            "a".into(),
+            "no".into(),
+            "yes".into(),
+            "é".into(), // 2-byte UTF-8, fits on 32-bit and 64-bit
+            "x".repeat(INLINE_CAPACITY),
+        ];
+        cases.dedup();
+
+        for s in &cases {
+            let a = IString::intern(s);
+            let b = IString::intern(s);
+
+            assert!(a.0.is_inline_string(), "{:?} should be inline", s);
+            assert_eq!(a.as_str(), s.as_str());
+            assert_eq!(a.as_bytes(), s.as_bytes());
+            assert_eq!(a.len(), s.len());
+            assert_eq!(a.is_empty(), s.is_empty());
+            assert_eq!(a, b);
+            // Value equality holds even though inline strings are not deduplicated
+            // to a shared allocation.
+            assert_eq!(a, IString::from(s.as_str()));
+        }
+    }
+
+    #[mockalloc::test]
+    fn inline_heap_boundary() {
+        // At the capacity boundary, one side is inline and the other is heap.
+        let inline = "x".repeat(INLINE_CAPACITY);
+        let heap = "x".repeat(INLINE_CAPACITY + 1);
+
+        let a = IString::intern(&inline);
+        let b = IString::intern(&heap);
+
+        assert!(a.0.is_inline_string());
+        assert!(!b.0.is_inline_string());
+        assert_eq!(a.as_str(), inline);
+        assert_eq!(b.as_str(), heap);
+        assert_ne!(a, b);
+        assert!(a < b); // ordering falls back to byte comparison
+    }
+
+    // Not a `mockalloc::test`: an all-inline test performs no allocations, which
+    // is exactly the point, but `mockalloc` treats zero allocations as an error.
+    #[test]
+    fn empty_string_is_inline() {
+        let a = IString::new();
+        let b = IString::intern("");
+
+        assert!(a.0.is_inline_string());
+        assert_eq!(a, b);
+        assert!(a.is_empty());
+        assert_eq!(a.as_str(), "");
+        // Empty is a string, not null.
+        assert!(!IValue::from(a).is_null());
+    }
+
+    #[mockalloc::test]
+    fn inline_and_heap_mix_in_object() {
+        // Short (inline) and long (heap) keys must both hash and look up correctly.
+        let mut obj = crate::IObject::new();
+        obj.insert("id", IValue::from(1));
+        obj.insert(LONG_A, IValue::from(2));
+        obj.insert("no", IValue::from(3));
+
+        assert_eq!(obj["id"], IValue::from(1));
+        assert_eq!(obj[LONG_A], IValue::from(2));
+        assert_eq!(obj["no"], IValue::from(3));
+        assert_eq!(obj.len(), 3);
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -179,17 +179,23 @@ impl IString {
     // pointer-sized value, avoiding any allocation or interning.
     fn new_inline(s: &str) -> Self {
         debug_assert!(s.len() <= INLINE_CAPACITY);
-        // The byte-sized inline flag must match the shared `usize` constant.
-        debug_assert_eq!(INLINE_STRING_FLAG, 0b100);
 
+        // Build the payload with the tag bits left clear; `IValue::new_inline`
+        // ORs in the `StringOrNull` tag. The control byte carries the inline
+        // flag and the length, and the remaining bytes carry the characters.
         let mut bytes = [0u8; std::mem::size_of::<usize>()];
         bytes[INLINE_CONTROL_OFFSET] =
-            TypeTag::StringOrNull as u8 | 0b100 | ((s.len() as u8) << INLINE_LEN_SHIFT);
+            INLINE_STRING_FLAG as u8 | ((s.len() as u8) << INLINE_LEN_SHIFT);
         bytes[INLINE_CHAR_OFFSET..INLINE_CHAR_OFFSET + s.len()].copy_from_slice(s.as_bytes());
 
-        // Safety: the control byte sets the `StringOrNull` tag and inline flag,
-        // so the value is non-zero and correctly discriminated.
-        unsafe { IString(IValue::new_inline_string(usize::from_ne_bytes(bytes))) }
+        // Safety: the inline flag keeps the value non-zero, and the payload
+        // leaves the tag bits clear.
+        unsafe {
+            IString(IValue::new_inline(
+                TypeTag::StringOrNull,
+                usize::from_ne_bytes(bytes),
+            ))
+        }
     }
 
     // The byte length of an inline string, read from the control byte.

--- a/src/value.rs
+++ b/src/value.rs
@@ -169,6 +169,12 @@ impl Deref for BoolMut<'_> {
 
 pub(crate) const ALIGNMENT: usize = 4;
 
+/// Bit 2 of a `StringOrNull`-tagged value flags an inline string (as opposed to
+/// a pointer to an interned heap string). Heap string headers are 8-aligned, so
+/// this bit is always clear for a heap string pointer, making it a reliable
+/// discriminator. See the `string` module for the full inline layout.
+pub(crate) const INLINE_STRING_FLAG: usize = 0b100;
+
 #[repr(usize)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum TypeTag {
@@ -226,6 +232,15 @@ impl IValue {
         Self::new_ptr(NonNull::from_ref(r).cast(), tag)
     }
 
+    // Safety: `bits` must be a valid inline-string encoding, i.e. non-zero,
+    // with the `StringOrNull` tag in the low bits and `INLINE_STRING_FLAG` set.
+    // See the `string` module for the layout.
+    pub(crate) unsafe fn new_inline_string(bits: usize) -> Self {
+        Self {
+            ptr: NonNull::new_unchecked(bits as *mut u8),
+        }
+    }
+
     /// JSON `null`.
     pub const NULL: Self = unsafe { Self::new_inline(TypeTag::StringOrNull) };
     /// JSON `false`.
@@ -263,6 +278,17 @@ impl IValue {
     }
     fn type_tag(&self) -> TypeTag {
         self.ptr_usize().into()
+    }
+
+    /// Returns `true` if this value is a string stored inline rather than as a
+    /// pointer to an interned heap allocation.
+    ///
+    /// Short strings are stored directly inside the pointer-sized value (see the
+    /// `string` module). They carry the `StringOrNull` tag with
+    /// [`INLINE_STRING_FLAG`] set; heap string headers are 8-aligned so that bit
+    /// is always clear for them, and `null` never has it set either.
+    pub(crate) fn is_inline_string(&self) -> bool {
+        self.type_tag() == TypeTag::StringOrNull && self.ptr_usize() & INLINE_STRING_FLAG != 0
     }
 
     /// Returns the type of this value.

--- a/src/value.rs
+++ b/src/value.rs
@@ -215,10 +215,14 @@ unsafe impl Send for IValue {}
 unsafe impl Sync for IValue {}
 
 impl IValue {
-    // Safety: Tag must not be `Number`
-    const unsafe fn new_inline(tag: TypeTag) -> Self {
+    // Safety: Tag must not be `Number`, and `payload` must leave the tag bits
+    // (the low `ALIGNMENT.trailing_zeros()` bits) clear so it does not corrupt
+    // the tag when ORed in. Used both for the inline singletons (payload `0`)
+    // and for inline strings (payload carries the inline flag, length, and
+    // characters — see the `string` module).
+    pub(crate) const unsafe fn new_inline(tag: TypeTag, payload: usize) -> Self {
         Self {
-            ptr: NonNull::new_unchecked(tag as usize as *mut u8),
+            ptr: NonNull::new_unchecked((tag as usize | payload) as *mut u8),
         }
     }
     // Safety: Pointer must be non-null and aligned to at least ALIGNMENT
@@ -232,21 +236,12 @@ impl IValue {
         Self::new_ptr(NonNull::from_ref(r).cast(), tag)
     }
 
-    // Safety: `bits` must be a valid inline-string encoding, i.e. non-zero,
-    // with the `StringOrNull` tag in the low bits and `INLINE_STRING_FLAG` set.
-    // See the `string` module for the layout.
-    pub(crate) unsafe fn new_inline_string(bits: usize) -> Self {
-        Self {
-            ptr: NonNull::new_unchecked(bits as *mut u8),
-        }
-    }
-
     /// JSON `null`.
-    pub const NULL: Self = unsafe { Self::new_inline(TypeTag::StringOrNull) };
+    pub const NULL: Self = unsafe { Self::new_inline(TypeTag::StringOrNull, 0) };
     /// JSON `false`.
-    pub const FALSE: Self = unsafe { Self::new_inline(TypeTag::ArrayOrFalse) };
+    pub const FALSE: Self = unsafe { Self::new_inline(TypeTag::ArrayOrFalse, 0) };
     /// JSON `true`.
-    pub const TRUE: Self = unsafe { Self::new_inline(TypeTag::ObjectOrTrue) };
+    pub const TRUE: Self = unsafe { Self::new_inline(TypeTag::ObjectOrTrue, 0) };
 
     pub(crate) fn ptr_usize(&self) -> usize {
         self.ptr.as_ptr() as usize


### PR DESCRIPTION
Closes #24.

Implements the inline short-string optimization sketched in the issue thread: strings up to `size_of::<usize>() - 1` bytes — **7 on 64-bit, 3 on 32-bit** — are encoded directly inside the pointer-sized `IValue`, skipping both the allocation and the global-cache lookup. This covers the common case of short JSON keys/values (`"id"`, `"no"`, `"yes"`, `"type"`, `"x"`, …). Longer strings are interned exactly as before.

## Encoding

An inline string reuses the `StringOrNull` tag and adds a discriminator in the low **control byte**:

| bits 0–1 | bit 2 | bits 3–5 | remaining bytes |
|---|---|---|---|
| tag `01` | `1` = inline | length | up to `INLINE_CAPACITY` UTF-8 bytes |

- Bit 2 distinguishes inline from a heap string pointer. For that to be reliable, the heap `Header` is now **8-aligned** so heap pointers always have bit 2 clear. On 64-bit that was already true (the `AtomicUsize` refcount forces 8-alignment); the explicit `#[repr(align(8))]` is what makes the optimization work on **32-bit** (costs ~4 bytes of header padding, only on interned strings).
- `null` (value `1`) has bit 2 clear, so it stays distinct from inline strings; the niche is preserved (inline values are non-zero), so `Option<IValue>` stays pointer-sized.

## Why it's sound

Everything rests on one invariant: **representation is a pure function of content** — `len ≤ INLINE_CAPACITY` ⇒ inline, otherwise interned. So two equal strings always share a representation, and `IString`'s pointer-based `==`/`hash` stay correct (an inline value's bits *are* its content).

## Endianness

The control byte is kept in the value's **low byte** on both endiannesses (so tag/flag/length live in well-defined bits via `ptr_usize()`); only the in-memory character offset differs, handled with `cfg(target_endian)`.

## Behaviour change

`IString::as_str().as_ptr()` is no longer stable across equal *short* strings — they're no longer deduplicated to a shared allocation (they use no heap at all). Value equality via `==` is unaffected. Two existing tests that asserted pointer identity for short strings were updated to use long strings; new tests cover the inline path.

## Validation

Full platform/endianness matrix:

| Target | How |
|---|---|
| x86-64 LE (native) | `cargo test` (36 pass) + `cargo miri test` (no UB) |
| i686 LE (32-bit) | `cargo test --target i686-pc-windows-msvc` (36 pass) |
| s390x BE (64-bit) | `cargo miri test --target s390x-…` (emulated, pass) |
| powerpc BE (32-bit) | `cargo miri test --target powerpc-…` (emulated, pass) |

Plus `clippy --all-targets --all-features` and `fmt --check` clean. New tests cover: inline round-trip for lengths 0..=CAP incl. multibyte UTF-8, the CAP/CAP+1 inline↔heap boundary, empty-string-is-inline-not-null, and mixed inline/heap keys in an `IObject`.

## Scope

Addresses request (1) fully and request (2) for the common case (short unique strings now cost nothing). Not interning **long** unique strings is a deliberate non-goal: without canonicalization, `IString`'s O(1) pointer equality/hash — the crate's core value — would break.
